### PR TITLE
[#33] meta/review FAISS Vector Store 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.py

--- a/workspace/hyewon/RAG/[vectorDb-meta-최종] 컬럼 전처리.py
+++ b/workspace/hyewon/RAG/[vectorDb-meta-최종] 컬럼 전처리.py
@@ -1,0 +1,179 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC ### _vector db_
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+import json
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 01. data load, preprocess
+
+# COMMAND ----------
+
+# raw data
+data=spark.read.json("dbfs:/data/meta-California.json.gz")
+
+# COMMAND ----------
+
+data.filter(col("state")!="Permanently closed").count()
+
+# COMMAND ----------
+
+null_data=data.filter(col("state").isNull())
+
+# COMMAND ----------
+
+closed_data=data.filter(col("state")!="Permanently closed")
+
+# COMMAND ----------
+
+final_data=null_data.union(closed_data)
+
+# COMMAND ----------
+
+final_data.count()
+
+# COMMAND ----------
+
+data=final_data.dropDuplicates(["gmap_id"])
+data.count()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### misc 전처리
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+# COMMAND ----------
+
+document=spark.sql("SELECT *FROM hive_metastore.silver.california_meta")
+
+# COMMAND ----------
+
+# 모든 컬럼 string으로 변환
+@udf(StringType())
+def convert_to_str(x):
+    return json.dumps(x)
+
+for col in document.columns:
+    if not isinstance(document.schema[col].dataType,StringType):
+        document=document.withColumn(col,convert_to_str(document[col]))
+
+# COMMAND ----------
+
+document.count()
+
+# COMMAND ----------
+
+import re
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+# MISC 정리
+@udf(returnType=StringType())
+def filter_null_and_empty_list(col_str):
+    if col_str is None or not isinstance(col_str, str):
+        return ""
+    # 정규식 패턴: null 또는 빈 리스트([])
+    pattern = re.compile(r'\[|\]|null|"')
+
+    # 패턴과 매칭되는 부분을 제거
+    filtered_str = pattern.sub('', col_str)
+
+    # 불필요한 쉼표와 공백 제거
+    filtered_str = re.sub(r'\s*,\s*', ',', filtered_str)
+    filtered_str = re.sub(r',+', ',', filtered_str)
+    
+    # 문자열의 시작과 끝에 있는 쉼표 제거
+    filtered_str = filtered_str.strip(', ')
+    return filtered_str
+
+document = document.withColumn("MISC", filter_null_and_empty_list(col("MISC")))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### category 전처리
+
+# COMMAND ----------
+
+import re
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+document = document.withColumn("category", filter_null_and_empty_list(col("category")))
+display(document.select("category").limit(1))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### hours 전처리
+
+# COMMAND ----------
+
+import re
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+
+@udf(returnType=StringType())
+def filter_hours(col_str):
+    # 정규식 패턴: null 또는 빈 리스트([])
+    pattern = re.compile(r'\[|null|"')
+    to_pattern=re.compile(r'\\u2013')
+    split_pattern=re.compile(r'\],')
+
+    # 패턴과 매칭되는 부분을 제거
+    filtered_str = pattern.sub('', col_str)
+    filtered_str= to_pattern.sub(" to ",filtered_str)
+    filtered_str= split_pattern.sub("/",filtered_str)
+    
+    # 불필요한 쉼표와 공백 제거
+    filtered_str = re.sub(r'\s*,\s*', ',', filtered_str)
+    filtered_str = re.sub(r',+', ',', filtered_str)
+
+    # 문자열의 시작과 끝에 있는 쉼표 제거
+    filtered_str = filtered_str.strip(', ')
+    filtered_str = filtered_str.rstrip(']]')
+    
+    return filtered_str
+
+document=document.withColumn("hours",filter_hours(col("hours")))
+
+# COMMAND ----------
+
+document.columns
+
+# COMMAND ----------
+
+exclude_cols=["region","relative_results"]
+
+all_columns=[col for col in document.columns if col not in exclude_cols]
+print(all_columns)
+
+# 모든 컬럼의 데이터를 하나의 문서로 병합
+@udf(returnType=StringType())
+def combine_columns(*cols):
+     return ". ".join([f"{name} is {str(col)}" for name, col in zip(all_columns, cols) if col is not None and str(col).lower() != 'null'])
+
+document=document.withColumn("combined_doc",combine_columns(*all_columns))
+
+# COMMAND ----------
+
+display(document.limit(1))
+
+# COMMAND ----------
+
+spark.sql("CREATE SCHEMA IF NOT EXISTS hive_metastore.vector_db")
+
+# COMMAND ----------
+
+document.write.mode("overwrite").saveAsTable("asacdataanalysis.vector_db.meta")

--- a/workspace/hyewon/RAG/[vectorDb-meta-최종]:faiss index,vector store 생성.py
+++ b/workspace/hyewon/RAG/[vectorDb-meta-최종]:faiss index,vector store 생성.py
@@ -1,0 +1,276 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC #### 00. environ setting
+
+# COMMAND ----------
+
+# MAGIC %pip install --upgrade langchain faiss-cpu mlflow
+
+# COMMAND ----------
+
+# MAGIC %pip install -U langchain-openai langchain-community
+
+# COMMAND ----------
+
+# MAGIC %restart_python
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+import json
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+import faiss
+
+from langchain.document_loaders import PySparkDataFrameLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from langchain import PromptTemplate
+
+# COMMAND ----------
+
+import config
+import os
+os.environ["OPENAI_API_KEY"]=config.OPENAI_API_KEY
+
+# COMMAND ----------
+
+embed_model=OpenAIEmbeddings()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### _vector db_
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 01. data load, preprocess
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### 데이터 로드 combined_doc load
+
+# COMMAND ----------
+
+document=spark.sql("SELECT gmap_id,combined_doc from asacdataanalysis.vector_db.meta")
+
+# COMMAND ----------
+
+doc_sample=document.sample(withReplacement=False, fraction=0.22)
+doc_sample.count()
+
+# COMMAND ----------
+
+doc_sample.write.mode("overwrite").saveAsTable('asacdataanalysis.vector_db.meta_sample2')
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### 비용 계산
+
+# COMMAND ----------
+
+# 전체 데이터 추출
+target_col="combined_doc"
+
+data_list=doc_sample.select(target_col).rdd.flatMap(lambda x:x).collect()
+
+# COMMAND ----------
+
+doc_str="".join(data_list)
+print(doc_str)
+
+# COMMAND ----------
+
+len(doc_str)
+
+# COMMAND ----------
+
+doc_str
+
+# COMMAND ----------
+
+import tiktoken
+
+encoding = tiktoken.get_encoding("cl100k_base")
+# 주어진 모델 이름에 대해 올바른 인코딩을 자동으로 로드
+encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
+
+result=encoding.encode(doc_str)
+
+# COMMAND ----------
+
+len(result)
+
+# COMMAND ----------
+
+len(encoding.encode(data_list[122]))
+
+# COMMAND ----------
+
+len(encoding.encode(doc_str))
+
+# COMMAND ----------
+
+cost_per_1M_tokens = 0.15
+total_tokens=24047905
+
+# 전체 비용 계산
+total_cost = (total_tokens / 1000000) * cost_per_1M_tokens
+print("cost:",total_cost)
+
+# COMMAND ----------
+
+total_cost
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 02. index 생성
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### 2. indexIVFPQ
+# MAGIC :HP(cluster, sub vector) 설정 후 인덱스 생성
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC document 생성
+
+# COMMAND ----------
+
+data_pandas=doc_sample.toPandas()
+
+# COMMAND ----------
+
+# ver 1: combined_doc에 모든 컬럼정보 저장
+from langchain_core.documents import Document
+
+docs=[Document(page_content=row["combined_doc"]) for index,row in data_pandas.iterrows()]
+
+# COMMAND ----------
+
+texts=[doc.page_content for doc in docs]
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 임베딩 및 테이블로 저장
+
+# COMMAND ----------
+
+embeddings_list=embed_model.embed_documents(texts)
+embeddings=np.array(embeddings_list,dtype="float32")
+
+# COMMAND ----------
+
+import pandas as pd
+
+embedding_df = pd.DataFrame(embeddings)
+
+spark_df = spark.createDataFrame(embedding_df)
+
+spark_df.write.mode("overwrite").saveAsTable('asacdataanalysis.vector_db.meta_embedding2')
+
+# COMMAND ----------
+
+# 샘플링 비율 설정 -> index.train이 너무 오래걸릴시 샘플링 사용 가능
+sample_size = int(len(embeddings) * 0.1)  # 0.1로 샘플링
+sample_indices = np.random.choice(len(embeddings), sample_size, replace=False)
+sample_embeddings = embeddings[sample_indices]
+len(sample_embeddings)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 인덱스 생성
+
+# COMMAND ----------
+
+index_path="meta_sample2.index"
+
+# COMMAND ----------
+
+# 인덱스 생성
+import faiss
+from langchain.embeddings import OpenAIEmbeddings
+
+dim=embeddings.shape[1] # 임베딩 벡터 차원
+
+ncentroids=int(np.sqrt(len(embeddings))) # 클러스터 수 - 데이터 수의 제곱근
+m=32 # sub vector 분할
+quantizer=faiss.IndexFlatL2(dim)
+
+index=faiss.IndexIVFPQ(quantizer,dim,ncentroids,m,8) # 서브벡터를 8 bits로 양자화
+
+faiss.normalize_L2(embeddings)
+
+index.train(embeddings) # train:샘플 데이터 가능 !
+
+index.add(embeddings) # add: 전체 데이터
+
+index.make_direct_map()
+
+faiss.write_index(index,index_path)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 03. 벡터 스토어 업로드
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 벡터 스토어 초기화
+
+# COMMAND ----------
+
+from uuid import uuid4
+
+uuids=[ str(uuid4()) for _ in range(len(embeddings))]
+
+# COMMAND ----------
+
+from langchain_community.docstore.in_memory import InMemoryDocstore
+
+# FAISS 인덱스에서 ID와 UUID 간의 매핑 생성
+index_to_docstore_id = {i: uuids[i] for i in range(len(uuids))}
+
+# 벡터 스토어 초기화 시 매핑 제공
+vector_store = FAISS(embedding_function=embed_model, index=index, docstore=InMemoryDocstore(), index_to_docstore_id=index_to_docstore_id)
+
+vector_store.add_documents(documents=docs, ids=uuids)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 벡터 스토어 로컬 저장 + dbfs 저장
+
+# COMMAND ----------
+
+vector_store_path="meta_sample2"
+vector_store.save_local(vector_store_path)
+
+# COMMAND ----------
+
+# 필요한 경우 DBFS 디렉토리 생성
+dbutils.fs.mkdirs("/vector_db/meta2")
+
+# COMMAND ----------
+
+# 로컬 작업 디렉토리에서 파일을 읽고 DBFS에 쓰기
+with open("/Workspace/Users/spdlqj888888@gmail.com/langchainRetrieval/meta_sample2/index.faiss", "rb") as f:
+    data = f.read()
+with open("/dbfs/vector_db/meta2/index.faiss", "wb") as f:
+    f.write(data)
+
+with open("/Workspace/Users/spdlqj888888@gmail.com/langchainRetrieval/meta_sample2/index.pkl", "rb") as f:
+    data = f.read()
+with open("/dbfs/vector_db/meta2/index.pkl", "wb") as f:
+    f.write(data)

--- a/workspace/hyewon/RAG/[vectorDb-meta-최종]:vectorDb검색,retriever연결.py
+++ b/workspace/hyewon/RAG/[vectorDb-meta-최종]:vectorDb검색,retriever연결.py
@@ -1,0 +1,205 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC #### 0.environ setting
+
+# COMMAND ----------
+
+# MAGIC %pip install --upgrade langchain faiss-cpu mlflow
+
+# COMMAND ----------
+
+# MAGIC %pip install -U langchain-openai langchain-community
+
+# COMMAND ----------
+
+# MAGIC %restart_python
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+import json
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+
+from langchain.document_loaders import PySparkDataFrameLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from langchain import PromptTemplate
+
+# COMMAND ----------
+
+import config
+import os
+os.environ["OPENAI_API_KEY"]=config.OPENAI_API_KEY
+
+# COMMAND ----------
+
+embed_openai=OpenAIEmbeddings()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### _vector db_ 
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 검색
+# MAGIC :vector store, index load
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC local vector store load
+
+# COMMAND ----------
+
+vector_store_path="meta_sample2"
+
+db=FAISS.load_local(vector_store_path,embed_openai, allow_dangerous_deserialization=True)
+# 내부 인덱스에 접근하여 Direct Map 초기화
+db.index.make_direct_map()
+
+retriever = db.as_retriever(search_type="mmr", search_kwargs={"k": 1})
+retriever.invoke("find some place where wheelcahir accessible place and avg_rating is over 3.0")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC llm model prompt template
+
+# COMMAND ----------
+
+# Prompt template
+from langchain.prompts import ChatPromptTemplate
+
+helpful_answer='The place that is open 24 hours, has over 10 reviews, and is located in Texas is:**JFIT STUDIOS**\n- Address: 9642 Jones Rd, Houston, TX 77065\n- Rating: 4.1\n- Number of Reviews: 18\n- Open 24 hours'
+
+template="""
+        Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+        \n{context}
+
+        \nQuestion: {question}
+
+        Helpful Answer: 
+        \nrecommended place: ** name **
+        \n
+        \n- Address: 
+        \n- Rating:
+        \n- Number of Reviews:
+        \n- hours:
+        \n- state:
+        \n- category:
+        \n- [Google Maps Link]
+        \n- [gmap_id]
+        """
+
+prompt = ChatPromptTemplate.from_template(template)
+
+# COMMAND ----------
+
+def format_docs(docs):
+    return '\n\n'.join([d.page_content for d in docs])
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### 검색
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 1. page_content field + openAI 임베딩
+
+# COMMAND ----------
+
+# 검색 page_content filed, embed:open_ai
+
+from langchain.chains import RetrievalQA
+from langchain.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_openai import ChatOpenAI
+
+test_query="find wheelchair accessible avg_rating is over 3.0" #우선 한문장으로 예시
+    
+def search_query(vector_store_path,query):
+    db=FAISS.load_local(vector_store_path,embed_openai, allow_dangerous_deserialization=True)
+    # db.index.make_direct_map()
+
+    retriever = db.as_retriever(search_type="mmr", search_kwargs={"k": 2})
+    llm_model=ChatOpenAI(model_name="gpt-4o-mini")
+
+    # ver1.retrievalQA chain 생성
+    retrieval_qa=RetrievalQA.from_chain_type(llm=llm_model,chain_type="stuff",retriever=retriever)
+    result=retrieval_qa.run(query)
+    print(result)
+
+    print("-------------------------------------------------------------------")
+    # ver2.chain
+    docs=retriever.get_relevant_documents(query)
+    chain= prompt | llm_model | StrOutputParser()
+
+    response = chain.invoke({'context': (format_docs(docs)), 'question':query})
+    print(response)
+
+search_query(vector_store_path,test_query)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 2. metadata field + HF 임베딩 (사용 x, 참고용)
+
+# COMMAND ----------
+
+# 검색 meta_data에 올린 정보
+from langchain.chains import RetrievalQA
+from langchain.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_openai import ChatOpenAI
+
+vector_store_path="meta_1000_v2"
+test_query="find some restaurant where wheelchair accessible avg_rating is over 3.0" #우선 한문장으로 예시
+    
+def search_query_meta_field(vector_store_path,query):
+    db=FAISS.load_local(vector_store_path,embed_model, allow_dangerous_deserialization=True)
+    db.index.make_direct_map()
+
+    retriever = db.as_retriever(search_type="mmr", search_kwargs={"k": 2})
+    llm_model=ChatOpenAI(model_name="gpt-4o-mini")
+
+    # ver1.retrievalQA chain 생성
+    retrieval_qa=RetrievalQA.from_chain_type(llm=llm_model,chain_type="stuff",retriever=retriever)
+    result=retrieval_qa.run(query)
+    print(result)
+
+    print("-------------------------------------------------------------------")
+    # ver2.chain
+    docs=retriever.get_relevant_documents(query)
+    chain= prompt | llm_model | StrOutputParser()
+
+    response = chain.invoke({'context': (format_docs_meta_field(docs)), 'question':query})
+    print(response)
+
+search_query_meta_field(vector_store_path,test_query)
+
+# COMMAND ----------
+
+# 더미: 기본 faiss index 유사도 검색
+
+import faiss
+test_query="find place where opens 24 hours" #우선 한문장으로 예시
+query_emb=model.embed_query(test_query)
+
+# 쿼리 임베딩을 numpy 배열로 변환하고 2차원 배열로 만듦
+query_emb = np.array(query_emb, dtype='float32').reshape(1, -1)
+
+k=5 # hyper-param 상위 k개의 가장 가까운 벡터수
+D,I=index.search(query_emb,k)
+# D : 쿼리와의 거리
+# I : 검색된 상위 k개 가까운 벡터들의 인덱스 배열
+# L2_score=[d for d in D][0]
+# ids=[i for i in I][0]
+print(D,I) 

--- a/workspace/hyewon/RAG/[vectorDb-review-최종] 컬럼 전처리.py
+++ b/workspace/hyewon/RAG/[vectorDb-review-최종] 컬럼 전처리.py
@@ -1,0 +1,244 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC ### _vector db_
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 01. data load, preprocess
+
+# COMMAND ----------
+
+# MAGIC %pip install emoji
+
+# COMMAND ----------
+
+# MAGIC %restart_python
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+import json
+
+# COMMAND ----------
+
+data=spark.sql("SELECT * FROM hive_metastore.silver.california_review")
+
+# COMMAND ----------
+
+data.count()
+
+# COMMAND ----------
+
+# review text가 존재하는 애들로 필터리
+data=data.filter(col("text")!="N/A")
+
+# COMMAND ----------
+
+data.count()
+
+# COMMAND ----------
+
+from pyspark.sql import functions as F
+
+data = data.orderBy(F.desc("gmap_id"))
+
+# COMMAND ----------
+
+all_columns=["gmap_id","name","rating","resp","text","time"]
+data=data.select(all_columns)
+
+# COMMAND ----------
+
+display(data.limit(5))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC resp 전처리
+# MAGIC : text 추출, N/A 제거, 이모지 묘사
+
+# COMMAND ----------
+
+import re
+import emoji
+from pyspark.sql.types import StringType
+from pyspark.sql.functions import *
+
+@udf(returnType=StringType())
+def filter_resp(resp):
+    resp_text = resp["text"]
+
+    if resp_text=="N/A":clean_text=""
+    else: clean_text = re.sub(r'\\n|\\u', '', resp_text)
+    
+    final_text=emoji.demojize(clean_text)
+    
+    return final_text
+
+data=data.withColumn("resp",filter_resp(col("resp")))
+
+# COMMAND ----------
+
+display(data.select("resp").limit(3))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC review text 전처리
+
+# COMMAND ----------
+
+import re
+import emoji
+from pyspark.sql.types import StringType
+from pyspark.sql.functions import *
+
+@udf(returnType=StringType())
+def filter_resp(text):
+
+    if text=="N/A":clean_text=""
+    else: clean_text = re.sub(r'\\n|\\u', '', text)
+    
+    final_text=emoji.demojize(clean_text)
+    
+    return final_text
+
+data=data.withColumn("text",filter_resp(col("text")))
+
+# COMMAND ----------
+
+display(data.select("text").limit(10))
+
+# COMMAND ----------
+
+data=data.drop(col("name"))
+
+# COMMAND ----------
+
+data.write.mode("overwrite").saveAsTable("hive_metastore.vector_db.reviews_filtered2")
+
+# COMMAND ----------
+
+document=data
+
+# COMMAND ----------
+
+# 모든 컬럼 string으로 변환
+@udf(StringType())
+def convert_to_str(x):
+    return json.dumps(x)
+
+for col in document.columns:
+    if not isinstance(document.schema[col].dataType,StringType):
+        document=document.withColumn(col,convert_to_str(document[col]))
+
+# COMMAND ----------
+
+@udf(returnType=StringType())
+def combine_columns(*cols):
+     return ". ".join([f"{name}:{str(col)}" for name, col in zip(all_columns, cols) if col is not None and str(col).lower() != 'null'])
+
+document=document.withColumn("combined_doc",combine_columns(*document.columns))
+
+# COMMAND ----------
+
+display(document.select("combined_doc").limit(2))
+
+# COMMAND ----------
+
+spark.sql("CREATE SCHEMA IF NOT EXISTS hive_metastore.vector_db")
+
+# COMMAND ----------
+
+document.write.mode("overwrite").saveAsTable("hive_metastore.vector_db.reviews_filtered2")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### +) meta 가게 이름 추가
+
+# COMMAND ----------
+
+review=spark.sql("SELECT *FROM hive_metastore.vector_db.reviews_filtered2")
+
+# COMMAND ----------
+
+review.count()
+
+# COMMAND ----------
+
+meta=spark.sql("SELECT name,gmap_id FROM hive_metastore.vector_db.raw_california_filtered3")
+
+# COMMAND ----------
+
+joined=review.join(meta,on="gmap_id")
+
+# COMMAND ----------
+
+joined.count()
+
+# COMMAND ----------
+
+display(joined.limit(5))
+
+# COMMAND ----------
+
+joined.write.mode("overwrite").saveAsTable("hive_metastore.vector_db.reviews_filtered3")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### gmap_id 기준으로 묶기 (사용 x, 참고용)
+
+# COMMAND ----------
+
+from pyspark.sql import functions as F
+
+df_grouped = data.groupBy("gmap_id").agg(
+    F.first("name").alias("name"),
+    F.concat_ws(",", F.collect_list("text")).alias("text_list"),
+    F.concat_ws(",", F.collect_list("resp")).alias("resp_list")
+)
+
+
+# COMMAND ----------
+
+df_grouped.count()
+
+# COMMAND ----------
+
+display(df_grouped.limit(10))
+
+# COMMAND ----------
+
+import re
+
+@udf(returnType=StringType())
+def filter_text_list(text):
+    return re.sub(r'\n', '', text)
+
+df_grouped=df_grouped.withColumn("text_cleaned",filter_text_list(col("text_list")))
+
+# COMMAND ----------
+
+display(df_grouped.limit(3))
+
+# COMMAND ----------
+
+import re
+
+@udf(returnType=StringType())
+def filter_resp_list(resp):
+    return re.sub(r',', '', resp)
+
+df_grouped=df_grouped.withColumn("resp_cleaned",filter_resp_list(col("resp_list")))
+
+# COMMAND ----------
+
+display(df_grouped.limit(3))
+
+# COMMAND ----------
+
+df_grouped.write.mode("overwrite").saveAsTable("hive_metastore.vector_db.reviews_groupby")

--- a/workspace/hyewon/RAG/[vectorDb-review-최종]:faiss index,vector store 생성.py
+++ b/workspace/hyewon/RAG/[vectorDb-review-최종]:faiss index,vector store 생성.py
@@ -1,0 +1,252 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC #### 00. environ setting
+
+# COMMAND ----------
+
+# MAGIC %pip install --upgrade langchain faiss-cpu mlflow
+
+# COMMAND ----------
+
+# MAGIC %pip install -U langchain-openai langchain-community
+
+# COMMAND ----------
+
+# MAGIC %pip install mlflow transformers
+
+# COMMAND ----------
+
+# MAGIC %restart_python
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+import json
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+import faiss
+
+from langchain.document_loaders import PySparkDataFrameLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from langchain import PromptTemplate
+
+
+# COMMAND ----------
+
+import config
+import os
+os.environ["OPENAI_API_KEY"]=config.OPENAI_API_KEY
+
+# COMMAND ----------
+
+embed_model=OpenAIEmbeddings()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### _vector db_
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 01. data load, preprocess
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### 데이터 로드 및 컬럼명 수정
+# MAGIC : llm model 의 이해를 돕기위해 더 자세한 컬럼명으로 수정
+
+# COMMAND ----------
+
+data=spark.sql("SELECT * FROM hive_metastore.vector_db.reviews_filtered3")
+
+# COMMAND ----------
+
+data.count()
+
+# COMMAND ----------
+
+all_columns=data.columns
+
+@udf(returnType=StringType())
+def combine_columns(*cols):
+     return ". ".join([f"{name} is {str(col)}" for name, col in zip(all_columns, cols) if col is not None and str(col).lower() != 'null'])
+
+data=data.withColumn("combined_doc",combine_columns(*data.columns))
+
+# COMMAND ----------
+
+data=data.withColumnRenamed("resp","response of store owner").withColumnRenamed("text","review").withColumnRenamed("name","place name")
+
+# COMMAND ----------
+
+display(data.limit(1))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 메타 샘플링에 있는 것만 필터링
+
+# COMMAND ----------
+
+meta=spark.sql("SELECT gmap_id FROM asacdataanalysis.vector_db.meta_sample2")
+
+# COMMAND ----------
+
+document=data.join(meta,on="gmap_id")
+document.count()
+
+# COMMAND ----------
+
+doc_sample=document.sample(withReplacement=False, fraction=0.0125)
+doc_sample.count()
+
+# COMMAND ----------
+
+display(doc_sample.limit(1))
+
+# COMMAND ----------
+
+# df 저장을 위한 컬럼명에 "_" 추가
+doc_sample_save=doc_sample.withColumnRenamed("response of store owner","response_of_store_owner").withColumnRenamed("place name","place_name")
+
+# COMMAND ----------
+
+doc_sample_save.write.mode("overwrite").saveAsTable('asacdataanalysis.vector_db.review_sample2')
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 03. index 생성
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ##### 2. indexIVFPQ
+# MAGIC :HP(cluster, sub vector) 설정 후 인덱스 생성
+
+# COMMAND ----------
+
+data_pandas=doc_sample.toPandas()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 임베딩 및 테이블로 저장
+
+# COMMAND ----------
+
+from langchain_core.documents import Document
+
+# combined_doc에 모든 컬럼정보 저장
+docs=[Document(id=str(index),page_content=row["combined_doc"]) for index,row in data_pandas.iterrows()]
+
+# COMMAND ----------
+
+texts=[doc.page_content for doc in docs]
+
+# COMMAND ----------
+
+embeddings_list=embed_model.embed_documents(texts)
+embeddings=np.array(embeddings_list,dtype="float32")
+
+# COMMAND ----------
+
+import pandas as pd
+
+embedding_df = pd.DataFrame(embeddings)
+
+spark_df = spark.createDataFrame(embedding_df)
+
+spark_df.write.mode("overwrite").saveAsTable('hive_metastore.vector_db.review_embedding3')
+
+# COMMAND ----------
+
+# 샘플링 비율 설정 -> index.train이 너무 오래걸릴시 샘플링 사용 가능
+sample_size = int(len(reduced_embeddings) * 0.1)  # 0.1로 샘플링
+sample_indices = np.random.choice(len(reduced_embeddings), sample_size, replace=False)
+sample_embeddings = reduced_embeddings[sample_indices]
+len(sample_embeddings)
+
+# COMMAND ----------
+
+index_path="review_sample3.index"
+
+# COMMAND ----------
+
+# 인덱스 생성
+import faiss
+from langchain.embeddings import OpenAIEmbeddings
+
+dim=embeddings.shape[1] # 임베딩 벡터 차원
+
+ncentroids=int(np.sqrt(len(embeddings))) # 클러스터 수 - 데이터 수의 제곱근
+m=32 # sub vector 분할
+quantizer=faiss.IndexFlatL2(dim)
+
+index=faiss.IndexIVFPQ(quantizer,dim,ncentroids,m,8) # 서브벡터를 8 bits로 양자화
+
+faiss.normalize_L2(embeddings)
+
+index.train(embeddings) # train:샘플 데이터 가능 !
+
+index.add(embeddings) # add: 전체 데이터
+
+index.make_direct_map()
+
+faiss.write_index(index,index_path)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 03. 벡터 스토어 업로드
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 벡터 스토어 초기화
+
+# COMMAND ----------
+
+from uuid import uuid4
+
+uuids=[ str(uuid4()) for _ in range(len(embeddings))]
+
+# COMMAND ----------
+
+from langchain_community.docstore.in_memory import InMemoryDocstore
+
+# FAISS 인덱스에서 ID와 UUID 간의 매핑 생성
+index_to_docstore_id = {i: uuids[i] for i in range(len(uuids))}
+
+# 벡터 스토어 초기화 시 매핑 제공
+vector_store = FAISS(embedding_function=embed_model, index=index, docstore=InMemoryDocstore(), index_to_docstore_id=index_to_docstore_id)
+
+vector_store.add_documents(documents=docs, ids=uuids)
+
+# COMMAND ----------
+
+vector_store_path="review_sample3"
+vector_store.save_local(vector_store_path)
+
+# COMMAND ----------
+
+# 필요한 경우 DBFS 디렉토리 생성
+dbutils.fs.mkdirs("/vector_db/review2")
+
+# COMMAND ----------
+
+# 로컬 작업 디렉토리에서 파일을 읽고 DBFS에 쓰기
+with open("/Workspace/Users/spdlqj888888@gmail.com/langchainRetrieval/review_sample3/index.faiss", "rb") as f:
+    data = f.read()
+with open("/dbfs/vector_db/review2/index.faiss", "wb") as f:
+    f.write(data)
+
+with open("/Workspace/Users/spdlqj888888@gmail.com/langchainRetrieval/review_sample3/index.pkl", "rb") as f:
+    data = f.read()
+with open("/dbfs/vector_db/review2/index.pkl", "wb") as f:
+    f.write(data)

--- a/workspace/hyewon/RAG/[vectorDb-review-최종]:vectorDb검색,retriever연결.py
+++ b/workspace/hyewon/RAG/[vectorDb-review-최종]:vectorDb검색,retriever연결.py
@@ -1,0 +1,191 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC #### 0.environ setting
+
+# COMMAND ----------
+
+# MAGIC %pip install --upgrade langchain faiss-cpu mlflow
+
+# COMMAND ----------
+
+# MAGIC %pip install -U langchain-openai langchain-community
+
+# COMMAND ----------
+
+# MAGIC %restart_python
+
+# COMMAND ----------
+
+from pyspark.sql.functions import *
+from pyspark.sql.types import *
+import json
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+
+from langchain.document_loaders import PySparkDataFrameLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from langchain import PromptTemplate
+
+# COMMAND ----------
+
+import config
+import os
+os.environ["OPENAI_API_KEY"]=config.OPENAI_API_KEY
+
+# COMMAND ----------
+
+embed_model=OpenAIEmbeddings()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### _vector db_ 
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC #### 검색
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC local vector store load
+
+# COMMAND ----------
+
+vector_store_path="review_sample3"
+
+# COMMAND ----------
+
+db=FAISS.load_local(vector_store_path,OpenAIEmbeddings(), allow_dangerous_deserialization=True)
+
+retriever = db.as_retriever(search_type="mmr", search_kwargs={"k": 2})
+retriever.invoke("recommend place that have positive reviews")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC llm model prompt template
+
+# COMMAND ----------
+
+# Prompt template
+from langchain.prompts import ChatPromptTemplate
+
+
+template="""
+        Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+        \n{context}
+
+        \nQuestion: {question}
+        \nrecommended place: ** name **
+        \n
+        \n- rating:
+        \n- review:
+        \n- [gmap_id]
+        """
+
+prompt = ChatPromptTemplate.from_template(template)
+
+# COMMAND ----------
+
+def format_docs(docs):
+    return '\n\n'.join([d.page_content for d in docs])
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 검색
+
+# COMMAND ----------
+
+test_query="recommend place that have positive reviews"
+
+# COMMAND ----------
+
+# 검색
+from langchain.chains import RetrievalQA
+from langchain.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_openai import ChatOpenAI
+
+def search_query(vector_store_path,query):
+    db=FAISS.load_local(vector_store_path,embed_model, allow_dangerous_deserialization=True)
+    retriever = db.as_retriever(search_type="mmr", search_kwargs={"k": 2})
+    llm_model=ChatOpenAI(model_name="gpt-4o-mini")
+    
+    docs=retriever.get_relevant_documents(query)
+    chain= prompt | llm_model | StrOutputParser()
+
+    response = chain.invoke({'context': (format_docs(docs)), 'question':query})
+    print(response)
+
+search_query(vector_store_path,test_query)
+
+# COMMAND ----------
+
+test_query1="find place that has clean, comfortable bed or has friendly staff." 
+search_query(vector_store_path,test_query1)
+
+# COMMAND ----------
+
+test_query2="recommend place that has visitors who visit that place twice "
+search_query(vector_store_path,test_query2)
+
+# COMMAND ----------
+
+test_query3="find place that has more than 100 reviews"
+search_query(vector_store_path,test_query3)
+
+# COMMAND ----------
+
+test_query4="recommend restaurant where most of reviews are positive"
+search_query(vector_store_path,test_query4)
+
+# COMMAND ----------
+
+test_query5="search restaurant where most of reviews are negative"
+search_query(vector_store_path,test_query5)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC 결과 확인용
+
+# COMMAND ----------
+
+document=spark.sql("SELECT * FROM hive_metastore.vector_db.meta_review")
+
+# COMMAND ----------
+
+test_query4="recommend restaurant where most of reviews are positive"
+
+display(document.filter(col("gmap_id")=="0x80857d0a0a76bb03:0xbaef9e24962b9a76"))
+
+# COMMAND ----------
+
+test_query4="remind restaurant where most of reviews are negative"
+
+display(document.filter(col("gmap_id")=="0x80dd4b7baa68a49b:0x211bc0aa067c364d"))
+
+# COMMAND ----------
+
+# 더미: 기본 faiss index 유사도 검색
+
+import faiss
+test_query="find place where opens 24 hours" #우선 한문장으로 예시
+query_emb=model.embed_query(test_query)
+
+# 쿼리 임베딩을 numpy 배열로 변환하고 2차원 배열로 만듦
+query_emb = np.array(query_emb, dtype='float32').reshape(1, -1)
+
+k=5 # hyper-param 상위 k개의 가장 가까운 벡터수
+D,I=index.search(query_emb,k)
+# D : 쿼리와의 거리
+# I : 검색된 상위 k개 가까운 벡터들의 인덱스 배열
+# L2_score=[d for d in D][0]
+# ids=[i for i in I][0]
+print(D,I) 


### PR DESCRIPTION
##  작업 내용: FAISS DB를 구축합니다

### Related issue 🛠
- closed #33 

#### 상세 작업 과정 🚧 
1. meta/review 데이터의 컬럼들에 대해 전처리를 진행
- meta: MISC, category, hours
- review: text, resp(text 추출, N/A 제거, 이모지 묘사)
- 공통: combined_doc라는 전체데이터가 담긴 문자열 컬럼을 추가<br>-> vectorDB 업로드 시 사용하는 Document 형식 중 page_content 필드에 넣기위해서

2. FAISS indexIV-FPQ 로 인덱스 생성
- Document의 page_content 임베딩
- n-centrods(클러스터 수) , m (서브벡터 분할 크기) 등의 HP를 설정
- normalize_L2(), train, add 등의 과정을 거쳐 인덱스 생성

4. Vector Store 생성
- document의 개별적인 id(docstore_id)로 지정할 uuid 생성
- documents를 uuid와 매핑하여 vector store 생성

5. 생성한 벡터스토어를 retriever로 검색 테스트
